### PR TITLE
feat: Install docker-compose and change its permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,11 @@ RUN sh -c "curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add
 RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce 
 
+# Docker Compose
+RUN \
+  curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+  chmod +x /usr/local/bin/docker-compose
+
 # MySQL Client
 ENV MYSQL_VERSION=0.8.10-1
 RUN \


### PR DESCRIPTION
Weird, still getting permission denied even though added. Made fork as a placeholder

In response to running compose within a jenkins pipeline, add the docker-compose library using curl per docker docs

Closes an issue here https://github.com/WPMedia/fusion/tree/PEN-1338-run-build-sh-build