### PR TITLE
Add support for emulators

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,9 @@ RUN \
   rm mysql-apt-config_${MYSQL_VERSION}_all.deb && \
   apt-get update && \
   apt-get install -y mysql-client
+
+# Emulator Support
+RUN apt-get install -y binfmt-support && update-binfmts --enable
   
 # Other Utils
 RUN apt-get install -y zip jq gettext


### PR DESCRIPTION
We're updating the Fusion engine build server to use buildx and I believe I'm hitting https://gitlab.alpinelinux.org/alpine/aports/-/issues/12406. This adds the `binfmt-support` and updates it so hopefully the emulator works correctly.

```
#6 1.669 Upgrading critical system libraries and apk-tools:
#6 1.670 (1/1) Upgrading apk-tools (2.10.3-r1 -> 2.10.6-r0)
#6 1.708 Executing busybox-1.29.3-r10.trigger
#6 1.712 ERROR: busybox-1.29.3-r10.trigger: script exited with error 1
#6 1.779 Continuing the upgrade transaction with new apk-tools:
```