### PR TITLE
[Tools Update] Updated nodejs, sbt and go versions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,5 +24,5 @@ jobs:
           USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           PASSWORD: ${{ secrets.DOCKERHUB_ACCESS_KEY }}
           IMAGE_NAME: "washpost/docker-jenkins"
-          TAG_NAME: "v1.22"
+          TAG_NAME: "v1.23"
           LATEST: "true"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ USER root
 
 # Node/Npm
 # https://github.com/nodesource/distributions
-RUN bash -c "curl -sL https://deb.nodesource.com/setup_20.x | bash -"
+RUN bash -c "curl -sL https://deb.nodesource.com/setup_22.x | bash -"
 RUN apt-get update && apt-get install -y nodejs
 
 # Python/pip, and wget
@@ -19,7 +19,7 @@ RUN apt-get install -y python3 python3-dev python3-pip wget
 # Scala/sbt
 # https://www.scala-sbt.org/
 COPY install-sbt.sh /tmp/install-sbt.sh
-ENV SBT_VERSION=1.9.0
+ENV SBT_VERSION=1.10.1
 RUN \
   sh /tmp/install-sbt.sh "${SBT_VERSION}" && \
   sbt sbtVersion -Dsbt.rootdir=true && \
@@ -27,8 +27,8 @@ RUN \
 
 # Go
 # https://go.dev/dl/
-RUN wget https://dl.google.com/go/go1.20.5.linux-amd64.tar.gz
-RUN tar -xvf go1.20.5.linux-amd64.tar.gz -C /usr/local
+RUN wget https://dl.google.com/go/go1.23.0.linux-amd64.tar.gz
+RUN tar -xvf go1.23.0.linux-amd64.tar.gz -C /usr/local
 
 # Firebase
 # https://firebase.google.com/docs/cli#install-cli-mac-linux

--- a/install-sbt.sh
+++ b/install-sbt.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SBT_VERSION="$1"
-EXPECTED_MD5="957ee58e0eb9a3840f1a91743fbbeab5"
+EXPECTED_MD5="3313925451929f8f137774844e3a9ee2"
 
 curl -vvv "https://scala.jfrog.io/artifactory/debian/sbt-${SBT_VERSION}.deb" --output "sbt-${SBT_VERSION}.deb"
 


### PR DESCRIPTION
Current Jenkins version (2.401.2) of tag v1.22 is incompatible with other tools (aws, blue ocean, jira). So updating tools to the latest to get the latest Jenkins.