### PR TITLE
[Tools Update] Trying to fix checkout nodejs issue

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Docker Build & Push to Docker Hub
         uses: opspresso/action-docker@v0.4.0


### PR DESCRIPTION
Fixing:
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/