### PR TITLE
[Tools Update] Downgrading java version from 17 to 11 for Android Signing Plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This image is based off the latest Jenkins LTS
-FROM jenkins/jenkins:lts
+FROM jenkins/jenkins:latest-jdk11
 
 # Install common build tools
 


### PR DESCRIPTION
Latest Docker Jenkins is using Java 17 but App Signing plugin is having issues with Java 17. Downgrading Java version to 11.
Ref: https://issues.jenkins.io/browse/JENKINS-71124.