### PR TITLE
[Tools Update] Added jdk21 as a tool

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,5 +24,5 @@ jobs:
           USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           PASSWORD: ${{ secrets.DOCKERHUB_ACCESS_KEY }}
           IMAGE_NAME: "washpost/docker-jenkins"
-          TAG_NAME: "v1.23"
+          TAG_NAME: "v1.24"
           LATEST: "true"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get install -y python3 python3-dev python3-pip wget
 
 # Java
 # This image based on a openjdk image.  Java already installed.
+RUN apt-get install -y openjdk-21-jdk
 
 # Scala/sbt
 # https://www.scala-sbt.org/


### PR DESCRIPTION
A couple of internal tools need both jdk 11 and 21 on the docker image. So installing jdk21 as a tool on jdk11 image.